### PR TITLE
Upped jasmine-core to ~3.8.0 in NG Sample

### DIFF
--- a/frontegg-angular-starter/package.json
+++ b/frontegg-angular-starter/package.json
@@ -35,7 +35,7 @@
     "@types/jasminewd2": "~2.0.3",
     "@types/node": "^12.11.1",
     "codelyzer": "^6.0.0",
-    "jasmine-core": "~3.6.0",
+    "jasmine-core": "~3.8.0",
     "jasmine-spec-reporter": "~5.0.0",
     "karma": "~5.0.0",
     "karma-chrome-launcher": "~3.1.0",


### PR DESCRIPTION
To resolve build dependency issues, I bumped jasmine-core from ~3.6.0 to ~3.8.0